### PR TITLE
Remove unused "dual monitor" code to be able to clock CPU faster.

### DIFF
--- a/src/credit_manager.c
+++ b/src/credit_manager.c
@@ -86,20 +86,9 @@ void deposit_credit(char *input) {
 
   credit->credit += deposit;
 
-  toggle_videomode();
-  cprintf("%d Cent eingezahlt fuer %s.\r\nRestguthaben: %d\r\n", deposit,
-          credit->nickname, credit->credit);
-  sprintf(print_buffer,
-          "%c%s - %d Cent eingezahlt fuer %s. Restguthaben: %d Cent\r", 17,
-          time, deposit, credit->nickname, credit->credit);
-  cprintf("%s", print_buffer);
-  toggle_videomode();
   print_the_buffer();
   cprintf("\r\nEinzahlung durchgefuehrt, druecke RETURN...\r\n");
   input = get_input();
-  toggle_videomode();
-  clrscr();
-  toggle_videomode();
 }
 
 static void new_credit(void) {

--- a/src/kasse.c
+++ b/src/kasse.c
@@ -197,11 +197,6 @@ static signed int buy(char *name, unsigned int price) {
     return 1;
   }
 
-  toggle_videomode();
-  cprintf("\r\n             *** VERKAUF ***\r\n\r\n");
-  cprintf("%dx %s", einheiten, name);
-  toggle_videomode();
-
   cprintf("\r\nAuf ein Guthaben kaufen? Wenn ja, Nickname eingeben:\r\n");
   {
     BYTE i;
@@ -276,11 +271,6 @@ static signed int buy(char *name, unsigned int price) {
       }
     }
   }
-  if (*nickname != '\0') {
-    toggle_videomode();
-    cprintf(" fuer %s\r\n", nickname);
-    toggle_videomode();
-  }
 
   if (*nickname != '\0' && *nickname != 32) {
     nickname_len = strlen(nickname);
@@ -316,9 +306,6 @@ static signed int buy(char *name, unsigned int price) {
       cprintf("\r\nVerbleibendes Guthaben fuer %s: %s. Druecke RETURN...\r\n",
               nickname, rest);
       textcolor(TC_LIGHT_GRAY);
-      toggle_videomode();
-      cprintf("\r\nDein Guthaben betraegt noch %s.\r\n", rest);
-      toggle_videomode();
       get_input();
       matches++;
     } else {
@@ -417,7 +404,11 @@ int main(void) {
   char *time;
 
   if (VIDEOMODE == 40)
-    toggle_videomode();
+    videomode(80);
+
+  /* clock CPU at double the speed (a whopping 2 Mhz!) */
+  fast();
+
   clrscr();
 
   /* Allocate logging buffer memory */
@@ -459,14 +450,8 @@ int main(void) {
       /* if the input starts with a digit, we will interpret it as a number
        * for the item to be sold */
       buy_stock(atoi(c));
-      toggle_videomode();
-      clrscr();
-      toggle_videomode();
     } else if (*c == 'f') {
       buy_custom();
-      toggle_videomode();
-      clrscr();
-      toggle_videomode();
     } else if (*c == 's') {
       save_items();
       save_credits();


### PR DESCRIPTION
We never used the C64/VIC-II monitor at events because we didn't have the space.
A nice side effect is we only need to call fast() once to double the CPU
frequency, which should speed up numeric computations.