### PR TITLE
Rework format_euro()

### DIFF
--- a/src/general.c
+++ b/src/general.c
@@ -75,15 +75,8 @@ char retry_or_quit(void) {
 }
 
 char *format_euro(char *s, int maxlen, int cent) {
-  int tmp = cent;
-  int len = strlen(",EUR");
-  while ((tmp /= 10) > 0)
-    ++len;
-  if (len >= maxlen)
+  if(snprintf(s,maxlen,"%3d,%02dEUR", cent/100, cent%100) > maxlen)
     return NULL;
-  // workaround to produce a leading zero for cents.. %0.2d won't work
-  sprintf(s, "%3d,%s%dEUR", cent / 100, ((cent % 100) < 10 ? "0" : ""),
-          cent % 100);
   return s;
 }
 


### PR DESCRIPTION
Should have been this way from the start. As of today, it's unclear
whether there has been a real bug in the library back then of just a
confusion between %02d and %0.2d.

An simple benchmark of 1000 iterations resulted in approximately
25% speedup at 1MHz and 12.5% speedup at 2MHz.